### PR TITLE
Keep real zero values, drop only empty

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -305,7 +305,7 @@ function app:timeline($node as node(), $model as map(*), $instance as xs:string,
                 {
                     let $timestamps := (for $jmx in $jmxs return app:time-to-milliseconds(xs:dateTime($jmx/jmx:timestamp)))
                     for $xpath at $n in $xpaths
-                    let $expression := "for $jmx in $jmxs return number((("|| $xpath ||"),0)[1])"
+                    let $expression := "for $jmx in $jmxs return number((("|| $xpath ||"),'NaN')[1])"
                     let $values := util:eval($expression, true())
                     return
                         <json:value json:array="true">
@@ -315,7 +315,7 @@ function app:timeline($node as node(), $model as map(*), $instance as xs:string,
                                 for $jmx at $pos in $jmxs
                                 let $val := $values[$pos]
                                 let $time := $timestamps[$pos]
-                                where $val  (: this line filters empty AND ZERO results out :)
+                                where $val = $val  (: this line filters NaN and empty results out :)
                                 order by $time ascending
                                 return
                                     <json:value json:array="true">

--- a/modules/test-timeline.xql
+++ b/modules/test-timeline.xql
@@ -53,9 +53,9 @@ declare function local:test-timeline(){
 
     return 
         (
-            (: local:test-timeline-brokers($node,$map,$instance,$type,$start,$end),
-            local:test-timeline-cpu($node,$map,$instance,$type,$start,$end) :)
             console:log("starting: duration: " || $start || "-" || $end),
+            local:test-timeline-brokers($node,$map,$instance,$type,$start,$end),
+            (: local:test-timeline-cpu($node,$map,$instance,$type,$start,$end) :)
             local:test-timeline-recentqueries($node,$map,$instance,$type,$start,$end),
             console:log("end")
         )


### PR DESCRIPTION
Merge this branch if you think (as I do), that we should keep real zero values in results (e.g. ActiveBrokers = 0), and filter out only empty values (like max or avg from an empty set of rows). After looking at the diagrams how they're presenting in both versions, I'd suggest this solution.