### PR TITLE
Timeline - Limit of concurrent queries

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -455,7 +455,25 @@ declare function app:process-time-interval-params($pstart as xs:string, $pend as
 
 declare function app:jmxs-for-time-interval($instance as xs:string, $start as xs:dateTime, $end as xs:dateTime) {
     util:log-system-out("jmx for time interval " || $start || " -> " || $end),
-    collection($config:data-root || "/" || $instance)/jmx:jmx[jmx:Database][xs:dateTime(./jmx:timestamp) ge $start][xs:dateTime(./jmx:timestamp) le $end]
+    
+    let $cached-timeline-start := session:get-attribute("cached-timeline-start")
+    let $cached-timeline-end := session:get-attribute("cached-timeline-end")
+    return
+        if($cached-timeline-start = $start and $cached-timeline-end = $end)
+        then (
+            util:log-system-out("FOUND"),
+            session:get-attribute("cached-timeline-jmxs")
+        ) else (
+            util:log-system-out("NOT FOUND"),
+            let $jmxs := collection($config:data-root || "/" || $instance)/jmx:jmx[jmx:Database]
+                    [xs:dateTime(jmx:timestamp) ge $start][xs:dateTime(jmx:timestamp) le $end]
+            return (
+                session:set-attribute("cached-timeline-jmxs", $jmxs),
+                session:set-attribute("cached-timeline-start", $start),
+                session:set-attribute("cached-timeline-end", $end),
+                $jmxs
+            )
+        )
 };
 
 declare

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -448,8 +448,8 @@ declare function app:slow-queries-graph($jmx) {
 (: Takes start & end parameters as strings and returns start & end time points as xs:dateTime.
  : The function returns a sequence of exactly 2 values: ($start, $end). :)
 declare function app:process-time-interval-params($pstart as xs:string, $pend as xs:string) as xs:dateTime+ {
-    let $end := xs:dateTime(if($pend = "") then (current-dateTime()) else ($pend))
-    let $start := xs:dateTime(if(not($pstart = "")) then ($pstart) else ($end - xs:dayTimeDuration('P1D')))
+    let $end := if($pend != "") then xs:dateTime($pend) else current-dateTime()
+    let $start := if($pstart != "") then xs:dateTime($pstart) else ($end - xs:dayTimeDuration('P1D'))
     return ($start, $end)
 };
 

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -445,6 +445,9 @@ declare function app:slow-queries-graph($jmx) {
     )    
 };
 
+declare function app:jmxs-for-time-interval($instance as xs:string, $start as xs:dateTime, $end as xs:dateTime) {
+    collection($config:data-root || "/" || $instance)/jmx:jmx[jmx:Database][xs:dateTime(./jmx:timestamp) ge $start][xs:dateTime(./jmx:timestamp) le $end]
+};
 
 declare
     %templates:wrap
@@ -454,7 +457,7 @@ declare
 function app:default-timeline($node as node(), $model as map(*), $instance as xs:string, $gid, $start as xs:string, $end as xs:string) {
     let $end := xs:dateTime(if($end = "") then (current-dateTime()) else ($end))
     let $start := xs:dateTime(if(not($start = "")) then ($start) else ($end - xs:dayTimeDuration('P1D')))
-    let $jmx := collection($config:data-root || "/" || $instance)/jmx:jmx[jmx:Database][xs:dateTime(./jmx:timestamp) ge $start][xs:dateTime(./jmx:timestamp) le $end]
+    let $jmx := app:jmxs-for-time-interval($instance, $start, $end)
     return     
         if ($jmx) then(
             let $result := <result>{
@@ -498,10 +501,8 @@ function app:timeline($node as node(), $model as map(*), $instance as xs:string,
 
     let $end := xs:dateTime(if($end = "") then (current-dateTime()) else ($end))
     let $start := xs:dateTime(if(not($start = "")) then ($start) else ($end - xs:dayTimeDuration('P1D')))
-    let $jmxs := collection($config:data-root || "/" || $instance)/jmx:jmx[jmx:Database][xs:dateTime(./jmx:timestamp) ge $start][xs:dateTime(./jmx:timestamp) le $end]
-    
+    let $jmxs := app:jmxs-for-time-interval($instance, $start, $end)
 
-    
     return
         if ($jmxs) then
             let $result :=

--- a/modules/test-timeline.xql
+++ b/modules/test-timeline.xql
@@ -53,9 +53,9 @@ declare function local:test-timeline(){
 
     return 
         (
-            (: local:test-timeline-brokers($node,$map,$instance,$type,$start,$end),
-            local:test-timeline-cpu($node,$map,$instance,$type,$start,$end) :)
             console:log("starting: duration: " || $start || "-" || $end),
+            local:test-timeline-brokers($node,$map,$instance,$type,$start,$end),
+            (: local:test-timeline-cpu($node,$map,$instance,$type,$start,$end) :)
             local:test-timeline-recentqueries($node,$map,$instance,$type,$start,$end),
             console:log("end")
         )

--- a/timeline-cache-lock.xml
+++ b/timeline-cache-lock.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root/>

--- a/timelines.html
+++ b/timelines.html
@@ -164,10 +164,13 @@
                             // console.log("dataset: ", dataset);
                             // console.log("options: ", options);
                             // console.log("loaded "+id);
+                            startNextTask();
                             var container = $("#" + id);
                             var data = dataset;
-                            startNextTask();
                             new $.TimelineSetup(container, data,options);
+                        },
+                        error: function(){
+                            startNextTask();
                         }
                     });
                 };

--- a/timelines.html
+++ b/timelines.html
@@ -134,6 +134,19 @@
     <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/bootstrap.daterangepicker/1/daterangepicker-bs3.css"/>
     <script type="text/javascript">
         $(document).ready(function() {
+            const concurrentQueries = 2;
+            var currentQueries = 0;
+            var scheduledTasks = [];
+
+            var startNextTask = function() {
+                var task = scheduledTasks.shift();
+                if(task) {
+                    task();
+                } else {
+                    currentQueries--;
+                }
+            };
+
             var timerange = $.TimerangeSetup();
             // console.log("timerange: ", timerange);
             var options = $.TimelineOptions();
@@ -142,24 +155,29 @@
                 var id = $( this ).attr("id") 
                 // console.log( index + ": " + id);
                 var url = "modules/update-timeline.xql" + $(location).attr('search') + "&amp;id=" + id;
-                $.ajax({
-                    url: url,
-                    method: 'GET',
-                    dataType: 'json',
-                    success: function(dataset){
-                        // console.log("dataset: ", dataset);
-                        // console.log("options: ", options);
-                        var container = $("#" + id);
-                        var data = dataset;
-                        new $.TimelineSetup(container, data,options);
-                    }
-                });   
-                
+                var task = function () {
+                    $.ajax({
+                        url: url,
+                        method: 'GET',
+                        dataType: 'json',
+                        success: function(dataset){
+                            // console.log("dataset: ", dataset);
+                            // console.log("options: ", options);
+                            // console.log("loaded "+id);
+                            var container = $("#" + id);
+                            var data = dataset;
+                            startNextTask();
+                            new $.TimelineSetup(container, data,options);
+                        }
+                    });
+                };
+                if(currentQueries &lt; concurrentQueries) {
+                    currentQueries++;
+                    task(); // starting directly
+                } else {
+                    scheduledTasks.push(task); // scheduling
+                }
             });
-            
-            
-
-      
         });
     </script>
 </div>


### PR DESCRIPTION
I introduced a limit of concurrent queries (to update-timeline), it is specified with const concurrentQueries. This change showed to give good results, the most important is that first graphs load much faster.
I'd recommend to use the value 2 for the constant. It may be worth to experiment with 3-4 if the server is powerful (multiprocessor) and not overloaded.
